### PR TITLE
add more HPGe operational voltages

### DIFF
--- a/pars/geds/opv/l200-p03-r000-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p03-r000-T%-all-opvs.yaml
@@ -1,202 +1,202 @@
-V02160A:
-  operational_voltage_in_V: 4000.0
-V02160B:
-  operational_voltage_in_V: 4400.0
-V05261B:
-  operational_voltage_in_V: 3700.0
-V05266A:
-  operational_voltage_in_V: 3800.0
-V05266B:
-  operational_voltage_in_V: 4700.0
-V05268B:
-  operational_voltage_in_V: 4300.0
-V05612A:
-  operational_voltage_in_V: 4300.0
-V07647A:
-  operational_voltage_in_V: 2800.0
-V07647B:
-  operational_voltage_in_V: 3900.0
-B00035C:
-  operational_voltage_in_V: 3200.0
-C000RG1:
-  operational_voltage_in_V: 4500.0
-C000RG2:
-  operational_voltage_in_V: 4000.0
-C00ANG3:
-  operational_voltage_in_V: 3500.0
-C00ANG5:
-  operational_voltage_in_V: 2000.0
-C00ANG2:
-  operational_voltage_in_V: 3700.0
-V00074A:
-  operational_voltage_in_V: 4300.0
-V04549A:
-  operational_voltage_in_V: 4000.0
-V07298B:
-  operational_voltage_in_V: 0.0
-B00032B:
-  operational_voltage_in_V: 3200.0
-B00091C:
-  operational_voltage_in_V: 3700.0
-P00574B:
-  operational_voltage_in_V: 1900.0
-P00665A:
-  operational_voltage_in_V: 0.0
-P00698A:
-  operational_voltage_in_V: 3000.0
-P00712A:
-  operational_voltage_in_V: 4500.0
-P00909C:
-  operational_voltage_in_V: 3300.0
-P00661B:
-  operational_voltage_in_V: 1400.0
-P00574A:
-  operational_voltage_in_V: 2000.0
-B00000B:
-  operational_voltage_in_V: 2500.0
-B00000C:
-  operational_voltage_in_V: 3200.0
-B00061A:
-  operational_voltage_in_V: 3600.0
-B00061C:
-  operational_voltage_in_V: 3700.0
-B00076C:
-  operational_voltage_in_V: 2600.0
-B00079B:
-  operational_voltage_in_V: 3000.0
-B00079C:
-  operational_voltage_in_V: 2900.0
-V01386A:
-  operational_voltage_in_V: 1600.0
-V01403A:
-  operational_voltage_in_V: 1000.0
-V01404A:
-  operational_voltage_in_V: 0.0
-V01406A:
-  operational_voltage_in_V: 3900.0
-V01415A:
-  operational_voltage_in_V: 2800.0
-V08682B:
-  operational_voltage_in_V: 3500.0
-V08682A:
-  operational_voltage_in_V: 3500.0
-V09372A:
-  operational_voltage_in_V: 4500.0
-V09374A:
-  operational_voltage_in_V: 4000.0
-V09724A:
-  operational_voltage_in_V: 3000.0
-V02162B:
-  operational_voltage_in_V: 4300.0
-V02166B:
-  operational_voltage_in_V: 4400.0
-V04199A:
-  operational_voltage_in_V: 4100.0
-V04545A:
-  operational_voltage_in_V: 4200.0
-V05267B:
-  operational_voltage_in_V: 3800.0
-V07646A:
-  operational_voltage_in_V: 4300.0
-V07302B:
-  operational_voltage_in_V: 4400.0
-B00089C:
-  operational_voltage_in_V: 3300.0
-B00089D:
-  operational_voltage_in_V: 3000.0
-C00ANG4:
-  operational_voltage_in_V: 3500.0
-V00048B:
-  operational_voltage_in_V: 3600.0
-V00050A:
-  operational_voltage_in_V: 3400.0
-V00050B:
-  operational_voltage_in_V: 3700.0
-V01387A:
-  operational_voltage_in_V: 3800.0
-V05261A:
-  operational_voltage_in_V: 3300.0
-V05268A:
-  operational_voltage_in_V: 3600.0
-V07302A:
-  operational_voltage_in_V: 3100.0
-B00002A:
-  operational_voltage_in_V: 2200.0
-B00089A:
-  operational_voltage_in_V: 3600.0
-B00091A:
-  operational_voltage_in_V: 3100.0
-B00091D:
-  operational_voltage_in_V: 3200.0
-P00537A:
-  operational_voltage_in_V: 1300.0
-P00538A:
-  operational_voltage_in_V: 2900.0
-P00573A:
-  operational_voltage_in_V: 1800.0
-P00661C:
-  operational_voltage_in_V: 2300.0
-P00662C:
-  operational_voltage_in_V: 4000.0
-P00664A:
-  operational_voltage_in_V: 1500.0
-P00665C:
-  operational_voltage_in_V: 2100.0
-P00748B:
-  operational_voltage_in_V: 4400.0
-P00909B:
-  operational_voltage_in_V: 2700.0
-B00091B:
-  operational_voltage_in_V: 2600.0
-B00000D:
-  operational_voltage_in_V: 3000.0
-B00002C:
-  operational_voltage_in_V: 2800.0
-B00032C:
-  operational_voltage_in_V: 3700.0
-B00032D:
-  operational_voltage_in_V: 3200.0
-B00035A:
-  operational_voltage_in_V: 3100.0
-B00035B:
-  operational_voltage_in_V: 3400.0
-B00061B:
-  operational_voltage_in_V: 3700.0
-B00089B:
-  operational_voltage_in_V: 3200.0
-V00048A:
-  operational_voltage_in_V: 3100.0
-V01240A:
-  operational_voltage_in_V: 2700.0
-V01389A:
-  operational_voltage_in_V: 2400.0
-V05267A:
-  operational_voltage_in_V: 2800.0
-V05612B:
-  operational_voltage_in_V: 4100.0
 B00000A:
-  operational_voltage_in_V: 1700.0
+  operational_voltage_in_V: 1700
+B00000B:
+  operational_voltage_in_V: 2500
+B00000C:
+  operational_voltage_in_V: 3200
+B00000D:
+  operational_voltage_in_V: 3000
+B00002A:
+  operational_voltage_in_V: 2200
 B00002B:
-  operational_voltage_in_V: 2300.0
+  operational_voltage_in_V: 2300
+B00002C:
+  operational_voltage_in_V: 2800
 B00032A:
-  operational_voltage_in_V: 2700.0
+  operational_voltage_in_V: 2700
+B00032B:
+  operational_voltage_in_V: 3200
+B00032C:
+  operational_voltage_in_V: 3700
+B00032D:
+  operational_voltage_in_V: 3200
+B00035A:
+  operational_voltage_in_V: 3100
+B00035B:
+  operational_voltage_in_V: 3400
+B00035C:
+  operational_voltage_in_V: 3200
+B00061A:
+  operational_voltage_in_V: 3600
+B00061B:
+  operational_voltage_in_V: 3700
+B00061C:
+  operational_voltage_in_V: 3700
+B00076C:
+  operational_voltage_in_V: 2600
+B00079B:
+  operational_voltage_in_V: 3000
+B00079C:
+  operational_voltage_in_V: 2900
+B00089A:
+  operational_voltage_in_V: 3600
+B00089B:
+  operational_voltage_in_V: 3200
+B00089C:
+  operational_voltage_in_V: 3300
+B00089D:
+  operational_voltage_in_V: 3000
+B00091A:
+  operational_voltage_in_V: 3100
+B00091B:
+  operational_voltage_in_V: 2600
+B00091C:
+  operational_voltage_in_V: 3700
+B00091D:
+  operational_voltage_in_V: 3200
+C000RG1:
+  operational_voltage_in_V: 4500
+C000RG2:
+  operational_voltage_in_V: 4000
+C00ANG2:
+  operational_voltage_in_V: 3700
+C00ANG3:
+  operational_voltage_in_V: 3500
+C00ANG4:
+  operational_voltage_in_V: 3500
+C00ANG5:
+  operational_voltage_in_V: 2000
+P00537A:
+  operational_voltage_in_V: 1300
+P00538A:
+  operational_voltage_in_V: 2900
 P00538B:
-  operational_voltage_in_V: 2600.0
+  operational_voltage_in_V: 2600
+P00573A:
+  operational_voltage_in_V: 1800
 P00573B:
-  operational_voltage_in_V: 2000.0
-P00575A:
-  operational_voltage_in_V: 2300.0
+  operational_voltage_in_V: 2000
+P00574A:
+  operational_voltage_in_V: 2000
+P00574B:
+  operational_voltage_in_V: 1900
 P00574C:
-  operational_voltage_in_V: 2000.0
+  operational_voltage_in_V: 2000
+P00575A:
+  operational_voltage_in_V: 2300
 P00661A:
-  operational_voltage_in_V: 1100.0
+  operational_voltage_in_V: 1100
+P00661B:
+  operational_voltage_in_V: 1400
+P00661C:
+  operational_voltage_in_V: 2300
 P00662A:
-  operational_voltage_in_V: 2300.0
+  operational_voltage_in_V: 2300
 P00662B:
-  operational_voltage_in_V: 2600.0
+  operational_voltage_in_V: 2600
+P00662C:
+  operational_voltage_in_V: 4000
+P00664A:
+  operational_voltage_in_V: 1500
+P00665A:
+  operational_voltage_in_V: 0
 P00665B:
-  operational_voltage_in_V: 0.0
-P00748A:
-  operational_voltage_in_V: 3100.0
+  operational_voltage_in_V: 0
+P00665C:
+  operational_voltage_in_V: 2100
+P00698A:
+  operational_voltage_in_V: 3000
 P00698B:
-  operational_voltage_in_V: 100.0
+  operational_voltage_in_V: 100
+P00712A:
+  operational_voltage_in_V: 4500
+P00748A:
+  operational_voltage_in_V: 3100
+P00748B:
+  operational_voltage_in_V: 4400
+P00909B:
+  operational_voltage_in_V: 2700
+P00909C:
+  operational_voltage_in_V: 3300
+V00048A:
+  operational_voltage_in_V: 3100
+V00048B:
+  operational_voltage_in_V: 3600
+V00050A:
+  operational_voltage_in_V: 3400
+V00050B:
+  operational_voltage_in_V: 3700
+V00074A:
+  operational_voltage_in_V: 4300
+V01240A:
+  operational_voltage_in_V: 2700
+V01386A:
+  operational_voltage_in_V: 1600
+V01387A:
+  operational_voltage_in_V: 3800
+V01389A:
+  operational_voltage_in_V: 2400
+V01403A:
+  operational_voltage_in_V: 1000
+V01404A:
+  operational_voltage_in_V: 0
+V01406A:
+  operational_voltage_in_V: 3900
+V01415A:
+  operational_voltage_in_V: 2800
+V02160A:
+  operational_voltage_in_V: 4000
+V02160B:
+  operational_voltage_in_V: 4400
+V02162B:
+  operational_voltage_in_V: 4300
+V02166B:
+  operational_voltage_in_V: 4400
+V04199A:
+  operational_voltage_in_V: 4100
+V04545A:
+  operational_voltage_in_V: 4200
+V04549A:
+  operational_voltage_in_V: 4000
+V05261A:
+  operational_voltage_in_V: 3300
+V05261B:
+  operational_voltage_in_V: 3700
+V05266A:
+  operational_voltage_in_V: 3800
+V05266B:
+  operational_voltage_in_V: 4700
+V05267A:
+  operational_voltage_in_V: 2800
+V05267B:
+  operational_voltage_in_V: 3800
+V05268A:
+  operational_voltage_in_V: 3600
+V05268B:
+  operational_voltage_in_V: 4300
+V05612A:
+  operational_voltage_in_V: 4300
+V05612B:
+  operational_voltage_in_V: 4100
+V07298B:
+  operational_voltage_in_V: 0
+V07302A:
+  operational_voltage_in_V: 3100
+V07302B:
+  operational_voltage_in_V: 4400
+V07646A:
+  operational_voltage_in_V: 4300
+V07647A:
+  operational_voltage_in_V: 2800
+V07647B:
+  operational_voltage_in_V: 3900
+V08682A:
+  operational_voltage_in_V: 3500
+V08682B:
+  operational_voltage_in_V: 3500
+V09372A:
+  operational_voltage_in_V: 4500
+V09374A:
+  operational_voltage_in_V: 4000
+V09724A:
+  operational_voltage_in_V: 3000

--- a/pars/geds/opv/l200-p06-r000-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p06-r000-T%-all-opvs.yaml
@@ -1,0 +1,106 @@
+B00000A:
+  operational_voltage_in_V: 2500
+B00000B:
+  operational_voltage_in_V: 2850
+B00000C:
+  operational_voltage_in_V: 3500
+B00000D:
+  operational_voltage_in_V: 3300
+B00002A:
+  operational_voltage_in_V: 2500
+B00002B:
+  operational_voltage_in_V: 3000
+B00002C:
+  operational_voltage_in_V: 3500
+B00032A:
+  operational_voltage_in_V: 3000
+B00032B:
+  operational_voltage_in_V: 3300
+B00032C:
+  operational_voltage_in_V: 4000
+B00032D:
+  operational_voltage_in_V: 4000
+B00035A:
+  operational_voltage_in_V: 4000
+B00035B:
+  operational_voltage_in_V: 4000
+B00035C:
+  operational_voltage_in_V: 3500
+B00061A:
+  operational_voltage_in_V: 4000
+B00061B:
+  operational_voltage_in_V: 4000
+B00061C:
+  operational_voltage_in_V: 4000
+B00076C:
+  operational_voltage_in_V: 3500
+B00079B:
+  operational_voltage_in_V: 3500
+B00079C:
+  operational_voltage_in_V: 3500
+B00089A:
+  operational_voltage_in_V: 4000
+B00089B:
+  operational_voltage_in_V: 3500
+B00089C:
+  operational_voltage_in_V: 3500
+B00089D:
+  operational_voltage_in_V: 4000
+B00091A:
+  operational_voltage_in_V: 3500
+B00091B:
+  operational_voltage_in_V: 2800
+B00091C:
+  operational_voltage_in_V: 4000
+P00538A:
+  operational_voltage_in_V: 3200
+P00573A:
+  operational_voltage_in_V: 2200
+P00573B:
+  operational_voltage_in_V: 2400
+P00574A:
+  operational_voltage_in_V: 2200
+P00574B:
+  operational_voltage_in_V: 2100
+P00574C:
+  operational_voltage_in_V: 2200
+P00575A:
+  operational_voltage_in_V: 2000
+P00662A:
+  operational_voltage_in_V: 2700
+P00662B:
+  operational_voltage_in_V: 2900
+P00662C:
+  operational_voltage_in_V: 4200
+P00665C:
+  operational_voltage_in_V: 2150
+P00698A:
+  operational_voltage_in_V: 3200
+P00712A:
+  operational_voltage_in_V: 4550
+P00748A:
+  operational_voltage_in_V: 4400
+P00748B:
+  operational_voltage_in_V: 4350
+P00909B:
+  operational_voltage_in_V: 3000
+V00048A:
+  operational_voltage_in_V: 3050
+V00050A:
+  operational_voltage_in_V: 3700
+V00050B:
+  operational_voltage_in_V: 3800
+V00074A:
+  operational_voltage_in_V: 4350
+V01387A:
+  operational_voltage_in_V: 3900
+V01389A:
+  operational_voltage_in_V: 2900
+V01406A:
+  operational_voltage_in_V: 5000
+V01415A:
+  operational_voltage_in_V: 3500
+V05261A:
+  operational_voltage_in_V: 3250
+V08682A:
+  operational_voltage_in_V: 3900

--- a/pars/geds/opv/l200-p06-r001-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p06-r001-T%-all-opvs.yaml
@@ -1,0 +1,2 @@
+V08682A:
+  operational_voltage_in_V: 3500

--- a/pars/geds/opv/l200-p07-r002-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p07-r002-T%-all-opvs.yaml
@@ -1,0 +1,22 @@
+B00000D:
+  operational_voltage_in_V: 3000
+B00076C:
+  operational_voltage_in_V: 3000
+P00573B:
+  operational_voltage_in_V: 2000
+P00662A:
+  operational_voltage_in_V: 2300
+P00664A:
+  operational_voltage_in_V: 1200
+V04545A:
+  operational_voltage_in_V: 4000
+V05261B:
+  operational_voltage_in_V: 4500
+V05268A:
+  operational_voltage_in_V: 4000
+V05268B:
+  operational_voltage_in_V: 4100
+V07302A:
+  operational_voltage_in_V: 2800
+V07647B:
+  operational_voltage_in_V: 4200

--- a/pars/geds/opv/l200-p08-r006-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p08-r006-T%-all-opvs.yaml
@@ -1,0 +1,2 @@
+P00712A:
+  operational_voltage_in_V: 4450

--- a/pars/geds/opv/l200-p09-r000-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p09-r000-T%-all-opvs.yaml
@@ -1,0 +1,16 @@
+V01387A:
+  operational_voltage_in_V: 4200
+V01389A:
+  operational_voltage_in_V: 3100
+V05261B:
+  operational_voltage_in_V: 3700
+V05266A:
+  operational_voltage_in_V: 3200
+V05267A:
+  operational_voltage_in_V: 2400
+V05268A:
+  operational_voltage_in_V: 3500
+V05268B:
+  operational_voltage_in_V: 3900
+V05612A:
+  operational_voltage_in_V: 2600

--- a/pars/geds/opv/l200-p14-r001-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p14-r001-T%-all-opvs.yaml
@@ -1,0 +1,94 @@
+B00000C:
+  operational_voltage_in_V: 3500
+B00000D:
+  operational_voltage_in_V: 3000
+B00002C:
+  operational_voltage_in_V: 3500
+B00032C:
+  operational_voltage_in_V: 4000
+B00035A:
+  operational_voltage_in_V: 4000
+B00035B:
+  operational_voltage_in_V: 4000
+B00061B:
+  operational_voltage_in_V: 4000
+B00076C:
+  operational_voltage_in_V: 3000
+B00079B:
+  operational_voltage_in_V: 1400
+B00079C:
+  operational_voltage_in_V: 3500
+V00048A:
+  operational_voltage_in_V: 3400
+V00048B:
+  operational_voltage_in_V: 3600
+V00050A:
+  operational_voltage_in_V: 3700
+V00050B:
+  operational_voltage_in_V: 3400
+V01240A:
+  operational_voltage_in_V: 2250
+V01404A:
+  operational_voltage_in_V: 2550
+V02160A:
+  operational_voltage_in_V: 4000
+V02160B:
+  operational_voltage_in_V: 4400
+V02162B:
+  operational_voltage_in_V: 4300
+V03421A:
+  operational_voltage_in_V: 2700
+V03422A:
+  operational_voltage_in_V: 4000
+V04199A:
+  operational_voltage_in_V: 4100
+V04545A:
+  operational_voltage_in_V: 4200
+V04549A:
+  operational_voltage_in_V: 4000
+V05266A:
+  operational_voltage_in_V: 3200
+V05266B:
+  operational_voltage_in_V: 4700
+V05267A:
+  operational_voltage_in_V: 2400
+V05267B:
+  operational_voltage_in_V: 4500
+V05612A:
+  operational_voltage_in_V: 2600
+V06643A:
+  operational_voltage_in_V: 2800
+V06659A:
+  operational_voltage_in_V: 2600
+V07298B:
+  operational_voltage_in_V: 4000
+V07302A:
+  operational_voltage_in_V: 2800
+V07302B:
+  operational_voltage_in_V: 4400
+V07646A:
+  operational_voltage_in_V: 4300
+V07647A:
+  operational_voltage_in_V: 2800
+V07647B:
+  operational_voltage_in_V: 4200
+V08682A:
+  operational_voltage_in_V: 3200
+V08682B:
+  operational_voltage_in_V: 3500
+V09372A:
+  operational_voltage_in_V: 4500
+V09374A:
+  operational_voltage_in_V: 4500
+V09724A:
+  operational_voltage_in_V: 3000
+V10447B:
+  operational_voltage_in_V: 4100
+V10784A:
+  operational_voltage_in_V: 3800
+V11924A:
+  operational_voltage_in_V: 4000
+V11925A:
+  operational_voltage_in_V: 3700
+V11947B:
+  operational_voltage_in_V: 4000

--- a/pars/geds/opv/l200-p14-r002-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p14-r002-T%-all-opvs.yaml
@@ -1,0 +1,14 @@
+V00048A:
+  operational_voltage_in_V: 0
+V00048B:
+  operational_voltage_in_V: 0
+V00050A:
+  operational_voltage_in_V: 0
+V01240A:
+  operational_voltage_in_V: 0
+V04545A:
+  operational_voltage_in_V: 3700
+V05267A:
+  operational_voltage_in_V: 0
+V10784A:
+  operational_voltage_in_V: 4200

--- a/pars/geds/opv/l200-p14-r003-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p14-r003-T%-all-opvs.yaml
@@ -1,0 +1,2 @@
+V04549A:
+  operational_voltage_in_V: 3500

--- a/pars/geds/opv/l200-p14-r004-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p14-r004-T%-all-opvs.yaml
@@ -1,0 +1,46 @@
+B00000D:
+  operational_voltage_in_V: 3500
+B00076C:
+  operational_voltage_in_V: 3500
+V00048A:
+  operational_voltage_in_V: 3400
+V00048B:
+  operational_voltage_in_V: 3600
+V00050A:
+  operational_voltage_in_V: 3400
+V00050B:
+  operational_voltage_in_V: 3500
+V01240A:
+  operational_voltage_in_V: 2350
+V02160A:
+  operational_voltage_in_V: 3500
+V03421A:
+  operational_voltage_in_V: 2600
+V03422A:
+  operational_voltage_in_V: 4100
+V04545A:
+  operational_voltage_in_V: 4200
+V04549A:
+  operational_voltage_in_V: 3800
+V05266B:
+  operational_voltage_in_V: 4750
+V05267A:
+  operational_voltage_in_V: 2400
+V05267B:
+  operational_voltage_in_V: 4700
+V06643A:
+  operational_voltage_in_V: 3000
+V06659A:
+  operational_voltage_in_V: 2800
+V07302A:
+  operational_voltage_in_V: 3100
+V07647A:
+  operational_voltage_in_V: 2700
+V07647B:
+  operational_voltage_in_V: 3900
+V08682A:
+  operational_voltage_in_V: 3400
+V09374A:
+  operational_voltage_in_V: 4000
+V11924A:
+  operational_voltage_in_V: 3700

--- a/pars/geds/opv/l200-p14-r005-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p14-r005-T%-all-opvs.yaml
@@ -1,0 +1,2 @@
+V06659A:
+  operational_voltage_in_V: 2600

--- a/pars/geds/opv/l200-p16-r%-T%-all-opvs.yaml
+++ b/pars/geds/opv/l200-p16-r%-T%-all-opvs.yaml
@@ -1,120 +1,120 @@
-V14654A:
-  operational_voltage_in_V: 4200.0
-V14673A:
-  operational_voltage_in_V: 4700.0
-V13044A:
-  operational_voltage_in_V: 2600.0
-B00032C:
-  operational_voltage_in_V: 3700.0
-V07302A:
-  operational_voltage_in_V: 2850.0
-V00050A:
-  operational_voltage_in_V: 3400.0
-V05267A:
-  operational_voltage_in_V: 2400.0
-V00048A:
-  operational_voltage_in_V: 3400.0
-V00048B:
-  operational_voltage_in_V: 2000.0
-V01240A:
-  operational_voltage_in_V: 2300.0
-V05268A:
-  operational_voltage_in_V: 350.0
-V05261A:
-  operational_voltage_in_V: 3300.0
-V03421A:
-  operational_voltage_in_V: 2600.0
-V03422A:
-  operational_voltage_in_V: 4000.0
-V10447B:
-  operational_voltage_in_V: 4100.0
-V08682A:
-  operational_voltage_in_V: 3900.0
-V09724A:
-  operational_voltage_in_V: 3000.0
-V11924A:
-  operational_voltage_in_V: 4000.0
-V09374A:
-  operational_voltage_in_V: 4000.0
-V02160A:
-  operational_voltage_in_V: 3500.0
-V02162B:
-  operational_voltage_in_V: 4300.0
-V05612A:
-  operational_voltage_in_V: 2600.0
-V05266A:
-  operational_voltage_in_V: 3800.0
-V07647A:
-  operational_voltage_in_V: 2800.0
-V07647B:
-  operational_voltage_in_V: 4200.0
-V07302B:
-  operational_voltage_in_V: 4400.0
-V05266B:
-  operational_voltage_in_V: 4750.0
-V14618A:
-  operational_voltage_in_V: 3900.0
-V13049A:
-  operational_voltage_in_V: 3000.0
-V13046A:
-  operational_voltage_in_V: 2100.0
 B00000C:
-  operational_voltage_in_V: 3200.0
-B00061B:
-  operational_voltage_in_V: 3700.0
-B00076C:
-  operational_voltage_in_V: 3000.0
-B00079B:
-  operational_voltage_in_V: 2050.0
-B00079C:
-  operational_voltage_in_V: 2900.0
-V06649M:
-  operational_voltage_in_V: 3150.0
-V01404A:
-  operational_voltage_in_V: 2550.0
+  operational_voltage_in_V: 3200
 B00000D:
-  operational_voltage_in_V: 3000.0
+  operational_voltage_in_V: 3000
 B00002C:
-  operational_voltage_in_V: 2800.0
+  operational_voltage_in_V: 2800
+B00032C:
+  operational_voltage_in_V: 3700
 B00035A:
-  operational_voltage_in_V: 3100.0
+  operational_voltage_in_V: 3100
 B00035B:
-  operational_voltage_in_V: 3400.0
+  operational_voltage_in_V: 3400
+B00061B:
+  operational_voltage_in_V: 3700
+B00076C:
+  operational_voltage_in_V: 3000
+B00079B:
+  operational_voltage_in_V: 2050
+B00079C:
+  operational_voltage_in_V: 2900
+V00048A:
+  operational_voltage_in_V: 3400
+V00048B:
+  operational_voltage_in_V: 2300
+V00050A:
+  operational_voltage_in_V: 3400
 V00050B:
-  operational_voltage_in_V: 3500.0
-V04549A:
-  operational_voltage_in_V: 3800.0
-V07298B:
-  operational_voltage_in_V: 4000.0
-V06643A:
-  operational_voltage_in_V: 3000.0
+  operational_voltage_in_V: 3500
 V00074A:
-  operational_voltage_in_V: 3850.0
-V08682B:
-  operational_voltage_in_V: 3500.0
-V11925A:
-  operational_voltage_in_V: 3700.0
-V11947B:
-  operational_voltage_in_V: 4000.0
-V09372A:
-  operational_voltage_in_V: 4500.0
-V10784A:
-  operational_voltage_in_V: 4200.0
-V10437B:
-  operational_voltage_in_V: 4000.0
+  operational_voltage_in_V: 3850
+V01240A:
+  operational_voltage_in_V: 2300
+V01404A:
+  operational_voltage_in_V: 2550
+V02160A:
+  operational_voltage_in_V: 3500
 V02160B:
-  operational_voltage_in_V: 4400.0
-V04199A:
-  operational_voltage_in_V: 4100.0
-V04545A:
-  operational_voltage_in_V: 4000.0
-V05267B:
-  operational_voltage_in_V: 4700.0
-V07646A:
-  operational_voltage_in_V: 4300.0
+  operational_voltage_in_V: 4400
+V02162B:
+  operational_voltage_in_V: 4300
 V02166B:
-  operational_voltage_in_V: 4400.0
+  operational_voltage_in_V: 4400
+V03421A:
+  operational_voltage_in_V: 2600
+V03422A:
+  operational_voltage_in_V: 4000
+V04199A:
+  operational_voltage_in_V: 4100
+V04545A:
+  operational_voltage_in_V: 4000
+V04549A:
+  operational_voltage_in_V: 3800
+V05261A:
+  operational_voltage_in_V: 3300
 V05261B:
-  operational_voltage_in_V: 3700.0
+  operational_voltage_in_V: 3700
+V05266A:
+  operational_voltage_in_V: 3800
+V05266B:
+  operational_voltage_in_V: 4750
+V05267A:
+  operational_voltage_in_V: 2400
+V05267B:
+  operational_voltage_in_V: 4700
+V05268A:
+  operational_voltage_in_V: 350
+V05612A:
+  operational_voltage_in_V: 2600
+V06643A:
+  operational_voltage_in_V: 3000
+V06649M:
+  operational_voltage_in_V: 3150
 V06659A:
-  operational_voltage_in_V: 2500.0
+  operational_voltage_in_V: 2500
+V07298B:
+  operational_voltage_in_V: 4000
+V07302A:
+  operational_voltage_in_V: 2850
+V07302B:
+  operational_voltage_in_V: 4400
+V07646A:
+  operational_voltage_in_V: 4300
+V07647A:
+  operational_voltage_in_V: 2800
+V07647B:
+  operational_voltage_in_V: 4200
+V08682A:
+  operational_voltage_in_V: 3900
+V08682B:
+  operational_voltage_in_V: 3500
+V09372A:
+  operational_voltage_in_V: 4500
+V09374A:
+  operational_voltage_in_V: 4000
+V09724A:
+  operational_voltage_in_V: 3000
+V10437B:
+  operational_voltage_in_V: 4000
+V10447B:
+  operational_voltage_in_V: 4100
+V10784A:
+  operational_voltage_in_V: 4200
+V11924A:
+  operational_voltage_in_V: 4000
+V11925A:
+  operational_voltage_in_V: 3700
+V11947B:
+  operational_voltage_in_V: 4000
+V13044A:
+  operational_voltage_in_V: 2600
+V13046A:
+  operational_voltage_in_V: 2100
+V13049A:
+  operational_voltage_in_V: 3000
+V14618A:
+  operational_voltage_in_V: 4200
+V14654A:
+  operational_voltage_in_V: 4200
+V14673A:
+  operational_voltage_in_V: 4700

--- a/pars/geds/opv/validity.yaml
+++ b/pars/geds/opv/validity.yaml
@@ -1,6 +1,57 @@
-- valid_from: 20230312T043356Z
+- valid_from: 20230311T235840Z
+  mode: reset
   apply:
     - l200-p03-r000-T%-all-opvs.yaml
+
+- valid_from: 20230611T174328Z
+  mode: append
+  apply:
+    - l200-p06-r000-T%-all-opvs.yaml
+
+- valid_from: 20230619T134311Z
+  mode: append
+  apply:
+    - l200-p06-r001-T%-all-opvs.yaml
+
+- valid_from: 20230814T101816Z
+  mode: append
+  apply:
+    - l200-p07-r002-T%-all-opvs.yaml
+
+- valid_from: 20231109T192557Z
+  mode: append
+  apply:
+    - l200-p08-r006-T%-all-opvs.yaml
+
+- valid_from: 20240110T233711Z
+  mode: append
+  apply:
+    - l200-p09-r000-T%-all-opvs.yaml
+
+- valid_from: 20250429T160544Z
+  mode: reset
+  apply:
+    - l200-p14-r001-T%-all-opvs.yaml
+
+- valid_from: 20250507T135236Z
+  mode: append
+  apply:
+    - l200-p14-r002-T%-all-opvs.yaml
+
+- valid_from: 20250516T165104Z
+  mode: append
+  apply:
+    - l200-p14-r003-T%-all-opvs.yaml
+
+- valid_from: 20250606T001858Z
+  mode: append
+  apply:
+    - l200-p14-r004-T%-all-opvs.yaml
+
+- valid_from: 20250617T022725Z
+  mode: append
+  apply:
+    - l200-p14-r005-T%-all-opvs.yaml
 
 - valid_from: 20251006T205904Z
   mode: reset


### PR DESCRIPTION
- detectors are sorted in the files
- voltages determined by querying the slow control. I asked for `vset` 30 minutes in the phy runs
- the timestamp in the validity file is the first timestamp of the calibration
- i have queried the slow control with the `nu24` runlist from legend-datasets