### PR TITLE
Fix regex pattern for confinement in simconfig.yaml

### DIFF
--- a/tier/stp/l200cfg09/simconfig.yaml
+++ b/tier/stp/l200cfg09/simconfig.yaml
@@ -29,7 +29,7 @@ hpge_bege_bulk_0vbb:
 hpge_V14_bulk_Ge68:
   template: $_/templates/default.mac
   generator: ~defines:Ge68
-  confinement: ~volumes.bulk:^[V14].*
+  confinement: ~volumes.bulk:^V14.*
   primaries_per_job: 500000
   number_of_jobs: 20
 


### PR DESCRIPTION
Fix for the Ge68 simulation regex. Currently matches anything starting in V, 1 or 4 ...