### PR TITLE
feat: add dead-material calorimeter outputs to l200 stp templates

### DIFF
--- a/tier/stp/l200cfg01/templates/default.mac
+++ b/tier/stp/l200cfg01/templates/default.mac
@@ -4,6 +4,20 @@
 /RMG/Geometry/RegisterDetectorsFromGDML Scintillator
 /RMG/Geometry/GDMLDisableOverlapCheck
 
+# record energy deposited in passive "dead" materials with the calorimeter
+# output scheme.
+# hpge_holding: HPGe support/cabling copper, ultem clamps & insulators, PhBr
+# springs & washers, LMFE, birds nest (everything but the PEN plates)
+/RMG/Geometry/RegisterDetector Calorimeter (hpge_(?!.*_pen).*)|birds_nest_plate_copper 90000001 0 true hpge_holding
+# fiber_support: LAr-instrumentation inner/outer support copper
+/RMG/Geometry/RegisterDetector Calorimeter larinstr_support_.*_copper.* 90000002 0 true fiber_support
+# calibration_sources: source capsule (steel + active), Ta absorber, PEEK
+# holder, Cu cap, and the nylon SIS guide tube (LAr buffers excluded). the
+# nylon tube is the only calibration volume always built (sources/absorbers
+# exist only when a SIS source is deployed), so keeping it in the pattern
+# avoids a zero-match remage warning in source-free runs.
+/RMG/Geometry/RegisterDetector Calorimeter calibration_(?!.*liquid_argon).* 90000003 0 true calibration_sources
+
 # name tables with ntuple
 /RMG/Output/NtupleUseVolumeName true
 

--- a/tier/stp/l200cfg01/templates/step_limits.mac
+++ b/tier/stp/l200cfg01/templates/step_limits.mac
@@ -4,6 +4,20 @@
 /RMG/Geometry/RegisterDetectorsFromGDML Scintillator
 /RMG/Geometry/GDMLDisableOverlapCheck
 
+# record energy deposited in passive "dead" materials with the calorimeter
+# output scheme.
+# hpge_holding: HPGe support/cabling copper, ultem clamps & insulators, PhBr
+# springs & washers, LMFE, birds nest (everything but the PEN plates)
+/RMG/Geometry/RegisterDetector Calorimeter (hpge_(?!.*_pen).*)|birds_nest_plate_copper 90000001 0 true hpge_holding
+# fiber_support: LAr-instrumentation inner/outer support copper
+/RMG/Geometry/RegisterDetector Calorimeter larinstr_support_.*_copper.* 90000002 0 true fiber_support
+# calibration_sources: source capsule (steel + active), Ta absorber, PEEK
+# holder, Cu cap, and the nylon SIS guide tube (LAr buffers excluded). the
+# nylon tube is the only calibration volume always built (sources/absorbers
+# exist only when a SIS source is deployed), so keeping it in the pattern
+# avoids a zero-match remage warning in source-free runs.
+/RMG/Geometry/RegisterDetector Calorimeter calibration_(?!.*liquid_argon).* 90000003 0 true calibration_sources
+
 # name tables with ntuple
 /RMG/Output/NtupleUseVolumeName true
 

--- a/tier/stp/l200cfg09/templates/default.mac
+++ b/tier/stp/l200cfg09/templates/default.mac
@@ -4,6 +4,20 @@
 /RMG/Geometry/RegisterDetectorsFromGDML Scintillator
 /RMG/Geometry/GDMLDisableOverlapCheck
 
+# record energy deposited in passive "dead" materials with the calorimeter
+# output scheme.
+# hpge_holding: HPGe support/cabling copper, ultem clamps & insulators, PhBr
+# springs & washers, LMFE, birds nest (everything but the PEN plates)
+/RMG/Geometry/RegisterDetector Calorimeter (hpge_(?!.*_pen).*)|birds_nest_plate_copper 90000001 0 true hpge_holding
+# fiber_support: LAr-instrumentation inner/outer support copper
+/RMG/Geometry/RegisterDetector Calorimeter larinstr_support_.*_copper.* 90000002 0 true fiber_support
+# calibration_sources: source capsule (steel + active), Ta absorber, PEEK
+# holder, Cu cap, and the nylon SIS guide tube (LAr buffers excluded). the
+# nylon tube is the only calibration volume always built (sources/absorbers
+# exist only when a SIS source is deployed), so keeping it in the pattern
+# avoids a zero-match remage warning in source-free runs.
+/RMG/Geometry/RegisterDetector Calorimeter calibration_(?!.*liquid_argon).* 90000003 0 true calibration_sources
+
 # name tables with ntuple
 /RMG/Output/NtupleUseVolumeName true
 

--- a/tier/stp/l200cfg09/templates/hpge-ethr-and-optics.mac
+++ b/tier/stp/l200cfg09/templates/hpge-ethr-and-optics.mac
@@ -4,6 +4,20 @@
 /RMG/Geometry/RegisterDetectorsFromGDML Optical
 /RMG/Geometry/GDMLDisableOverlapCheck
 
+# record energy deposited in passive "dead" materials with the calorimeter
+# output scheme.
+# hpge_holding: HPGe support/cabling copper, ultem clamps & insulators, PhBr
+# springs & washers, LMFE, birds nest (everything but the PEN plates)
+/RMG/Geometry/RegisterDetector Calorimeter (hpge_(?!.*_pen).*)|birds_nest_plate_copper 90000001 0 true hpge_holding
+# fiber_support: LAr-instrumentation inner/outer support copper
+/RMG/Geometry/RegisterDetector Calorimeter larinstr_support_.*_copper.* 90000002 0 true fiber_support
+# calibration_sources: source capsule (steel + active), Ta absorber, PEEK
+# holder, Cu cap, and the nylon SIS guide tube (LAr buffers excluded). the
+# nylon tube is the only calibration volume always built (sources/absorbers
+# exist only when a SIS source is deployed), so keeping it in the pattern
+# avoids a zero-match remage warning in source-free runs.
+/RMG/Geometry/RegisterDetector Calorimeter calibration_(?!.*liquid_argon).* 90000003 0 true calibration_sources
+
 # name tables with ntuple
 /RMG/Output/NtupleUseVolumeName true
 

--- a/tier/stp/l200cfg09/templates/hpge-ethr.mac
+++ b/tier/stp/l200cfg09/templates/hpge-ethr.mac
@@ -4,6 +4,20 @@
 /RMG/Geometry/RegisterDetectorsFromGDML Scintillator
 /RMG/Geometry/GDMLDisableOverlapCheck
 
+# record energy deposited in passive "dead" materials with the calorimeter
+# output scheme.
+# hpge_holding: HPGe support/cabling copper, ultem clamps & insulators, PhBr
+# springs & washers, LMFE, birds nest (everything but the PEN plates)
+/RMG/Geometry/RegisterDetector Calorimeter (hpge_(?!.*_pen).*)|birds_nest_plate_copper 90000001 0 true hpge_holding
+# fiber_support: LAr-instrumentation inner/outer support copper
+/RMG/Geometry/RegisterDetector Calorimeter larinstr_support_.*_copper.* 90000002 0 true fiber_support
+# calibration_sources: source capsule (steel + active), Ta absorber, PEEK
+# holder, Cu cap, and the nylon SIS guide tube (LAr buffers excluded). the
+# nylon tube is the only calibration volume always built (sources/absorbers
+# exist only when a SIS source is deployed), so keeping it in the pattern
+# avoids a zero-match remage warning in source-free runs.
+/RMG/Geometry/RegisterDetector Calorimeter calibration_(?!.*liquid_argon).* 90000003 0 true calibration_sources
+
 # name tables with ntuple
 /RMG/Output/NtupleUseVolumeName true
 

--- a/tier/stp/l200cfg09/templates/step_limits.mac
+++ b/tier/stp/l200cfg09/templates/step_limits.mac
@@ -4,6 +4,20 @@
 /RMG/Geometry/RegisterDetectorsFromGDML Scintillator
 /RMG/Geometry/GDMLDisableOverlapCheck
 
+# record energy deposited in passive "dead" materials with the calorimeter
+# output scheme.
+# hpge_holding: HPGe support/cabling copper, ultem clamps & insulators, PhBr
+# springs & washers, LMFE, birds nest (everything but the PEN plates)
+/RMG/Geometry/RegisterDetector Calorimeter (hpge_(?!.*_pen).*)|birds_nest_plate_copper 90000001 0 true hpge_holding
+# fiber_support: LAr-instrumentation inner/outer support copper
+/RMG/Geometry/RegisterDetector Calorimeter larinstr_support_.*_copper.* 90000002 0 true fiber_support
+# calibration_sources: source capsule (steel + active), Ta absorber, PEEK
+# holder, Cu cap, and the nylon SIS guide tube (LAr buffers excluded). the
+# nylon tube is the only calibration volume always built (sources/absorbers
+# exist only when a SIS source is deployed), so keeping it in the pattern
+# avoids a zero-match remage warning in source-free runs.
+/RMG/Geometry/RegisterDetector Calorimeter calibration_(?!.*liquid_argon).* 90000003 0 true calibration_sources
+
 # name tables with ntuple
 /RMG/Output/NtupleUseVolumeName true
 


### PR DESCRIPTION
## Summary

Add three remage **Calorimeter** output-scheme detectors to the `l200cfg01` and `l200cfg09` `stp` template macros to record energy deposited in the passive ("dead") materials of the `legend-pygeom-l200` geometry. Each `RegisterDetector` call groups all physical volumes matched by the regex (full-string `std::regex_match`) into a single output table via a shared uid + `allow_id_reuse`.

## Volumes per output table

**`hpge_holding`** (uid `90000001`) — HPGe holding structure, everything but the PEN plates:
- copper: clamp pins (hv/signal), hv/signal cables, string supports (hanger, rod, tristar, weldment), birds-nest plate
- ultem: clamps (hv/signal), insulators
- phosphor bronze: springs and washers (hv/signal)
- silica: LMFE
- excluded: `hpge_assembly_plate_pen_*`, `hpge_assembly_top_ring_pen_*`

**`fiber_support`** (uid `90000002`):
- `larinstr_support_inner_copper_*`, `larinstr_support_outer_copper_*`

**`calibration_sources`** (uid `90000003`):
- source capsule (steel container + active material), Ta absorber, PEEK holder, Cu cap, nylon SIS guide tube
- excluded: the LAr buffer volumes (`*liquid_argon*`)
- the source/absorber materials exist only when a SIS source is deployed; the nylon SIS guide tube is the only calibration volume always built, so it is intentionally kept in the pattern to guarantee a non-empty match and avoid a zero-match remage warning in source-free runs

## Why these uids

`90000001`–`90000003` are arbitrary group ids (not real channels). They are deliberately chosen as 8-digit values, **above the entire 7-digit LEGEND rawid space** that GDML-assigned detector uids draw from. Across the full channelmap every real rawid is 7-digit (currently 1,027,200–2,004,823 over geds/spms/pmts/auxs), so an 8-digit value cannot collide with any current or future GDML detector uid, while staying far below the `int` limit. Verified with remage 0.24: registration produces no uid collision.

## Validation

Tested end-to-end with remage 0.24 (the `Calorimeter` type requires **remage >= 0.20**; note the simflow currently pins `0.19.5`):
- the regexes match exactly the intended volumes (2172 / 97 / 4 in the source-free geometry; the calibration group additionally picks up the steel/source/Ta/PEEK/Cu volumes when a Th228 source is deployed), with PEN, LAr and active detectors excluded
- the three named tables are produced under `/stp` with `edep` data
- **performance checked:** per-event simulation cost +0–10% (worst case = decays inside the dead material; ~0–3% for bulk-Ge sims), plus a one-time ~70 s initialization to register the sensitive volumes (negligible for multi-hour production jobs)
- **output size checked:** +~1% for a 10k-event "decays in the Cu support" run (where the `hpge_holding` table is the actual signal); far smaller for sims where little energy reaches dead materials

## Scope

- `l200cfg01`: `default.mac`, `step_limits.mac`
- `l200cfg09`: `default.mac`, `hpge-ethr.mac`, `hpge-ethr-and-optics.mac`, `step_limits.mac`
- requires **remage >= 0.20**
