### PR TITLE
Setting up musun input from revertex

### DIFF
--- a/tier/stp/l200cfg01/simconfig.yaml
+++ b/tier/stp/l200cfg01/simconfig.yaml
@@ -421,3 +421,11 @@ liquid_argon_Ar39:
   confinement: ~defines:lar_inside_wlsr
   primaries_per_job: 35000000
   number_of_jobs: 10
+
+muon_hall_c:
+  template: $_/templates/muon.mac
+  generator: ~vertices:musun_hall_c
+  primaries_per_job: 1000
+  number_of_jobs: 1
+  macro_substitutions:
+    HADRONIC_PHYSICS: Shielding

--- a/tier/stp/l200cfg01/simconfig.yaml
+++ b/tier/stp/l200cfg01/simconfig.yaml
@@ -429,3 +429,4 @@ muon_hall_c:
   number_of_jobs: 1
   macro_substitutions:
     HADRONIC_PHYSICS: Shielding
+  custom_G4NDL: G4NDL.4.7.1

--- a/tier/stp/l200cfg01/templates/muon.mac
+++ b/tier/stp/l200cfg01/templates/muon.mac
@@ -6,6 +6,15 @@
 
 /RMG/Processes/HadronicPhysics {HADRONIC_PHYSICS}
 
+# to have event-by-event energy conservation even if not entirely physically correct
+/process/had/particle_hp/use_photo_evaporation True
+
+# recommended according to https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/TrackingAndPhysics/physicsProcess.html?highlight=particle_hp#high-precision-neutron-interactions-neutronhp
+/process/had/particle_hp/do_not_adjust_final_state True
+/process/had/particle_hp/skip_missin_isotopes True
+
+$MAURINA_GAMMA_CASCADES
+
 # record energy deposited in passive "dead" materials with the calorimeter
 # output scheme.
 # hpge_holding: HPGe support/cabling copper, ultem clamps & insulators, PhBr

--- a/tier/stp/l200cfg01/templates/muon.mac
+++ b/tier/stp/l200cfg01/templates/muon.mac
@@ -1,0 +1,52 @@
+/RMG/Manager/Randomization/Seed {SEED}
+
+/RMG/Geometry/RegisterDetectorsFromGDML Germanium
+/RMG/Geometry/RegisterDetectorsFromGDML Scintillator
+/RMG/Geometry/GDMLDisableOverlapCheck
+
+/RMG/Processes/HadronicPhysics {HADRONIC_PHYSICS}
+
+# record energy deposited in passive "dead" materials with the calorimeter
+# output scheme.
+# hpge_holding: HPGe support/cabling copper, ultem clamps & insulators, PhBr
+# springs & washers, LMFE, birds nest (everything but the PEN plates)
+/RMG/Geometry/RegisterDetector Calorimeter (hpge_(?!.*_pen).*)|birds_nest_plate_copper 90000001 0 true hpge_holding
+# fiber_support: LAr-instrumentation inner/outer support copper
+/RMG/Geometry/RegisterDetector Calorimeter larinstr_support_.*_copper.* 90000002 0 true fiber_support
+# calibration_sources: source capsule (steel + active), Ta absorber, PEEK
+# holder, Cu cap, and the nylon SIS guide tube (LAr buffers excluded). the
+# nylon tube is the only calibration volume always built (sources/absorbers
+# exist only when a SIS source is deployed), so keeping it in the pattern
+# avoids a zero-match remage warning in source-free runs.
+/RMG/Geometry/RegisterDetector Calorimeter calibration_(?!.*liquid_argon).* 90000003 0 true calibration_sources
+
+# name tables with ntuple
+/RMG/Output/NtupleUseVolumeName true
+
+# physics options
+/RMG/Processes/EnableGammaAngularCorrelation true
+
+/run/initialize
+
+# store everything in single precision
+/RMG/Output/Germanium/StoreSinglePrecisionPosition
+/RMG/Output/Germanium/StoreSinglePrecisionEnergy
+/RMG/Output/Scintillator/StoreSinglePrecisionPosition
+/RMG/Output/Scintillator/StoreSinglePrecisionEnergy
+/RMG/Output/Vertex/StoreSinglePrecisionPosition
+
+# do not track optical photons if no energy in germanium
+/RMG/Output/Germanium/DiscardWaitingTracksUnlessGermaniumEdep
+
+# do not store events with no energy deposition in germanium
+/RMG/Output/Germanium/EdepCutLow 1 eV
+
+# store trackid
+/RMG/Output/Germanium/StoreTrackID true
+/RMG/Output/Scintillator/StoreTrackID true
+
+$GENERATOR
+
+$CONFINEMENT
+
+/run/beamOn {N_EVENTS}

--- a/tier/stp/l200cfg09/simconfig.yaml
+++ b/tier/stp/l200cfg09/simconfig.yaml
@@ -377,6 +377,14 @@ liquid_argon_Ar39:
   primaries_per_job: 35000000
   number_of_jobs: 10
 
+muon_hall_c:
+  template: $_/templates/muon.mac
+  generator: ~vertices:musun_hall_c
+  primaries_per_job: 1000
+  number_of_jobs: 1
+  macro_substitutions:
+    HADRONIC_PHYSICS: Shielding
+
 # p16-ssc simulations
 # -------------------
 

--- a/tier/stp/l200cfg09/simconfig.yaml
+++ b/tier/stp/l200cfg09/simconfig.yaml
@@ -384,6 +384,7 @@ muon_hall_c:
   number_of_jobs: 1
   macro_substitutions:
     HADRONIC_PHYSICS: Shielding
+  custom_G4NDL: G4NDL.4.7.1
 
 # p16-ssc simulations
 # -------------------

--- a/tier/stp/l200cfg09/templates/muon.mac
+++ b/tier/stp/l200cfg09/templates/muon.mac
@@ -4,7 +4,7 @@
 /RMG/Geometry/RegisterDetectorsFromGDML Scintillator
 /RMG/Geometry/GDMLDisableOverlapCheck
 
-/RMG/Processes/HadronicPhysics {HADRONIC_PHYSICS}
+/RMG/Processes/HadronicPhysics $HADRONIC_PHYSICS
 
 # record energy deposited in passive "dead" materials with the calorimeter
 # output scheme.

--- a/tier/stp/l200cfg09/templates/muon.mac
+++ b/tier/stp/l200cfg09/templates/muon.mac
@@ -6,6 +6,15 @@
 
 /RMG/Processes/HadronicPhysics $HADRONIC_PHYSICS
 
+# to have event-by-event energy conservation even if not entirely physically correct
+/process/had/particle_hp/use_photo_evaporation True
+
+# recommended according to https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/TrackingAndPhysics/physicsProcess.html?highlight=particle_hp#high-precision-neutron-interactions-neutronhp
+/process/had/particle_hp/do_not_adjust_final_state True
+/process/had/particle_hp/skip_missin_isotopes True
+
+$MAURINA_GAMMA_CASCADES
+
 # record energy deposited in passive "dead" materials with the calorimeter
 # output scheme.
 # hpge_holding: HPGe support/cabling copper, ultem clamps & insulators, PhBr

--- a/tier/stp/l200cfg09/templates/muon.mac
+++ b/tier/stp/l200cfg09/templates/muon.mac
@@ -1,0 +1,52 @@
+/RMG/Manager/Randomization/Seed {SEED}
+
+/RMG/Geometry/RegisterDetectorsFromGDML Germanium
+/RMG/Geometry/RegisterDetectorsFromGDML Scintillator
+/RMG/Geometry/GDMLDisableOverlapCheck
+
+/RMG/Processes/HadronicPhysics {HADRONIC_PHYSICS}
+
+# record energy deposited in passive "dead" materials with the calorimeter
+# output scheme.
+# hpge_holding: HPGe support/cabling copper, ultem clamps & insulators, PhBr
+# springs & washers, LMFE, birds nest (everything but the PEN plates)
+/RMG/Geometry/RegisterDetector Calorimeter (hpge_(?!.*_pen).*)|birds_nest_plate_copper 90000001 0 true hpge_holding
+# fiber_support: LAr-instrumentation inner/outer support copper
+/RMG/Geometry/RegisterDetector Calorimeter larinstr_support_.*_copper.* 90000002 0 true fiber_support
+# calibration_sources: source capsule (steel + active), Ta absorber, PEEK
+# holder, Cu cap, and the nylon SIS guide tube (LAr buffers excluded). the
+# nylon tube is the only calibration volume always built (sources/absorbers
+# exist only when a SIS source is deployed), so keeping it in the pattern
+# avoids a zero-match remage warning in source-free runs.
+/RMG/Geometry/RegisterDetector Calorimeter calibration_(?!.*liquid_argon).* 90000003 0 true calibration_sources
+
+# name tables with ntuple
+/RMG/Output/NtupleUseVolumeName true
+
+# physics options
+/RMG/Processes/EnableGammaAngularCorrelation true
+
+/run/initialize
+
+# store everything in single precision
+/RMG/Output/Germanium/StoreSinglePrecisionPosition
+/RMG/Output/Germanium/StoreSinglePrecisionEnergy
+/RMG/Output/Scintillator/StoreSinglePrecisionPosition
+/RMG/Output/Scintillator/StoreSinglePrecisionEnergy
+/RMG/Output/Vertex/StoreSinglePrecisionPosition
+
+# do not track optical photons if no energy in germanium
+/RMG/Output/Germanium/DiscardWaitingTracksUnlessGermaniumEdep
+
+# do not store events with no energy deposition in germanium
+/RMG/Output/Germanium/EdepCutLow 1 eV
+
+# store trackid
+/RMG/Output/Germanium/StoreTrackID true
+/RMG/Output/Scintillator/StoreTrackID true
+
+$GENERATOR
+
+$CONFINEMENT
+
+/run/beamOn {N_EVENTS}

--- a/tier/vtx/l200cfg01/simconfig.yaml
+++ b/tier/vtx/l200cfg01/simconfig.yaml
@@ -37,3 +37,13 @@ hpge_coax_pplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors P* --surface-type pplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+
+musun_hall_c:
+  command: >-
+    revertex musun-gs --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+    --default-dimensions hall_c
+
+musun_original:
+  command: >-
+    revertex musun-gs --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+    --default-dimensions original

--- a/tier/vtx/l200cfg01/simconfig.yaml
+++ b/tier/vtx/l200cfg01/simconfig.yaml
@@ -2,48 +2,58 @@ hpge_ic_nplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors V* --surface-type nplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 hpge_bege_nplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors B* --surface-type nplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 hpge_ppc_nplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors P* --surface-type nplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 hpge_coax_nplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors P* --surface-type nplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 hpge_ic_pplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors V* --surface-type pplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 hpge_bege_pplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors B* --surface-type pplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 hpge_ppc_pplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors P* --surface-type pplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 hpge_coax_pplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors P* --surface-type pplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 musun_hall_c:
   command: >-
     revertex musun-gs --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
     --default-dimensions hall_c
+  product: kinematics_and_positions
 
 musun_original:
   command: >-
     revertex musun-gs --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
     --default-dimensions original
+  product: kinematics_and_positions

--- a/tier/vtx/l200cfg09/simconfig.yaml
+++ b/tier/vtx/l200cfg09/simconfig.yaml
@@ -17,3 +17,13 @@ hpge_bege_pplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors B* --surface-type pplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+
+musun_hall_c:
+  command: >-
+    revertex musun-gs --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+    --default-dimensions hall_c
+
+musun_original:
+  command: >-
+    revertex musun-gs --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+    --default-dimensions original

--- a/tier/vtx/l200cfg09/simconfig.yaml
+++ b/tier/vtx/l200cfg09/simconfig.yaml
@@ -2,28 +2,34 @@ hpge_ic_nplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors V* --surface-type nplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 hpge_bege_nplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors B* --surface-type nplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 hpge_ic_pplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors V* --surface-type pplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 hpge_bege_pplus_surface:
   command: >-
     revertex hpge-surf-pos --detectors B* --surface-type pplus --gdml
     {GDML_FILE} --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
+  product: positions
 
 musun_hall_c:
   command: >-
     revertex musun-gs --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
     --default-dimensions hall_c
+  product: kinematics_and_positions
 
 musun_original:
   command: >-
     revertex musun-gs --out-file {OUTPUT_FILE} --n-events {N_EVENTS}
     --default-dimensions original
+  product: kinematics_and_positions


### PR DESCRIPTION
Also requires some adjustments to legend-simflow (will reference pr once created).
So far, only hall_c and the original have been implemented, as the hall_a default-dimension option is not yet implemented in the revertex pr [[link](https://github.com/legend-exp/revertex/pull/42/changes#diff-f457bcf30bae0bfeba09b760bcc9f31c25334d4a9d7717773a927f03bede488f)].
I got it to run up to and including stp during testing.